### PR TITLE
fix(sec): upgrade org.springframework:spring-core to 5.2.19.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>4.3.21.RELEASE</version>
+            <version>5.2.19.RELEASE</version>
         </dependency>
         <!-- spring end -->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-core 4.3.21.RELEASE
- [CVE-2021-22060](https://www.oscs1024.com/hd/CVE-2021-22060)


### What did I do？
Upgrade org.springframework:spring-core from 4.3.21.RELEASE to 5.2.19.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS